### PR TITLE
Fixed intro cutscene titles

### DIFF
--- a/src/asm/Level_Select.asm
+++ b/src/asm/Level_Select.asm
@@ -204,6 +204,8 @@ add r8,r8,r9		#store next stage
 stw r8,0(r3)
 lis r3,-32385		#backup next stage for reset 
 stw r8,0(r3)
+lwz r3,-0x6060(r13)	#set episode flag (use -0x6138 for PAL or -0x6830 for JP)
+stb r9,0x00DF(r3)
 b done
 
 setupPinna: 


### PR DESCRIPTION
The game stores the episode number at offset `0x00DC` inside the flag manager, and uses it to determine what episode title to display during the intro cutscene and in the pause menu. That address is set to 0 upon exiting area, so the intro cutscene always showed the title for episode 1 when using the level select code.

This commit fixes the intro cutscene issue by writing the low byte of `r9` into the flag manager, but secret areas and special stages will still display episode 1 (or 2 for Mecha-Bowser and the Sirena 5 casino) in the pause menu. A possible workaround for this is to manually set the episode number in another register and write that to the flag manager.

A pointer to the flag manager can be found at `r13 - 0x6060` on PAL, `r13 - 0x6138` on NTSC-U, or `r13 - 0x6830` on NTSC-J.